### PR TITLE
fix guns/vim-sexp element-wise navigation

### DIFF
--- a/syntax/fennel.vim
+++ b/syntax/fennel.vim
@@ -61,7 +61,7 @@ exec 'syn match fennelNumber /' . fennel#number#Hex() . '/'
 " NOTE: Fennel seems to accept fractional and postfix 'p' in hex number even if Lua version < 5.2.
 
 " String {{{2
-syn region fennelString matchgroup=fennelDelimiter start=/"/ skip=/\\\\\|\\"/ end=/"/ contains=@fennelEscapeChars,@Spell
+syn region fennelString matchgroup=fennelStringDelimiter start=/"/ skip=/\\\\\|\\"/ end=/"/ contains=@fennelEscapeChars,@Spell
 syn cluster fennelEscapeChars contains=fennelEscapeLiteral,fennelEscapeMnemonic,fennelEscapeMnemonicZ,fennelEscapeCharCode
 syn match fennelEscapeLiteral /\\[\\"']/ contained
 syn match fennelEscapeMnemonic /\\[abfnrtv]/ contained
@@ -221,6 +221,7 @@ hi def link fennelKeyword Identifier
 hi def link fennelBoolean Boolean
 hi def link fennelNumber Number
 hi def link fennelString String
+hi def link fennelStringDelimiter Delimiter
 hi def link fennelEscapeLiteral Character
 hi def link fennelEscapeMnemonic Character
 hi def link fennelEscapeMnemonicZ fennelComment


### PR DESCRIPTION
Nice work on this plugin. This patch fixes element-wise navigation (e.g. `]e`, `ie`, `is`) in [guns/vim-sexp](https://github.com/guns/vim-sexp). I wish I knew why.