### PR TITLE
Highlight `where`

### DIFF
--- a/syntax/fennel.vim
+++ b/syntax/fennel.vim
@@ -157,6 +157,8 @@ syn keyword fennelAuxSyntax &as
 syn match fennelAuxSyntax /\<?\ze\([^[:space:]\n"'(),;@\[\]\\`{}~]\|\>\)/ contained containedin=fennelIdentifier
 " Special suffix for gensym in macro
 syn match fennelAuxSyntax /[^[:space:]\n"'(),;@\[\]\\`{}~]\zs#\>/ contained containedin=fennelIdentifier
+" TODO: Would be better to highlight `where` and `or` only inside `match` macro
+syn keyword fennelAuxSyntax where
 
 " Lua keywords {{{2
 syn keyword fennelLuaKeyword _G _VERSION


### PR DESCRIPTION
Close #4 for the moment.
It would be better to highlight `where` and `or` only inside `match` macro.