### PR TITLE
Catch up with recent changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - More granular highlighting for string escape sequences:
   - `\z` and `\x..` are supported by Lua>=5.2 or LuaJIT, highlighted as error otherwise.
   - `\u{..}` is supported by Lua>=5.3, highlighted as error otherwise.
+- Support `case`, `case-try`, and `faccumulate` macros (Fennel 1.3.0)
 - Support `fcollect` macro (Fennel 1.2.0)
 - Support `&into` and `&until` keywords in loops (Fennel 1.2.0).
 - Support `match-try` macro (Fennel 1.1.0).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 
 ### Fixed
 
+- `&` in identifier is now highlighted as error (Fennel 1.0.0).
+- Remove highlight for `doc` since it has been replaced with `,doc` (Fennel 1.0.0)
 - Remove highlight for `pick-args` since it has been deprecated (Fennel 0.10.0)
 
 ## [0.2][v0.2] (2021-06-20)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - More granular highlighting for string escape sequences:
   - `\z` and `\x..` are supported by Lua>=5.2 or LuaJIT, highlighted as error otherwise.
   - `\u{..}` is supported by Lua>=5.3, highlighted as error otherwise.
+- Support `tail!` and `assert-repl` macros (Fennel 1.4.0)
 - Support `case`, `case-try`, and `faccumulate` macros (Fennel 1.3.0)
 - Support `fcollect` macro (Fennel 1.2.0)
 - Support `&into` and `&until` keywords in loops (Fennel 1.2.0).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - More granular highlighting for string escape sequences:
   - `\z` and `\x..` are supported by Lua>=5.2 or LuaJIT, highlighted as error otherwise.
   - `\u{..}` is supported by Lua>=5.3, highlighted as error otherwise.
+- Support `fcollect` macro (Fennel 1.2.0)
+- Support `&into` and `&until` keywords in loops (Fennel 1.2.0).
 - Support `match-try` macro (Fennel 1.1.0).
 - Support `accumulate` macro (Fennel 0.10.0).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ### Fixed
 
+- Support missing `?.`, `comment?`, and `get-scope`
 - Remove highlight for `global` since it has been deprecated (Fennel 1.1.0)
 - `&` in identifier is now highlighted as error (Fennel 1.0.0).
 - Remove highlight for `doc` since it has been replaced with `,doc` (Fennel 1.0.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,12 @@
 - More granular highlighting for string escape sequences:
   - `\z` and `\x..` are supported by Lua>=5.2 or LuaJIT, highlighted as error otherwise.
   - `\u{..}` is supported by Lua>=5.3, highlighted as error otherwise.
-- Support `accumulate` macro.
+- Support `match-try` macro (Fennel 1.1.0).
+- Support `accumulate` macro (Fennel 0.10.0).
 
 ### Fixed
 
+- Remove highlight for `global` since it has been deprecated (Fennel 1.1.0)
 - `&` in identifier is now highlighted as error (Fennel 1.0.0).
 - Remove highlight for `doc` since it has been replaced with `,doc` (Fennel 1.0.0)
 - Remove highlight for `pick-args` since it has been deprecated (Fennel 0.10.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,24 +4,26 @@
 
 ### Added
 
+- Support Fennel 1.4.0:
+  - `tail!` and `assert-repl` macros (Fennel 1.4.0)
+  - `case`, `case-try`, and `faccumulate` macros (Fennel 1.3.0)
+  - `fcollect` macro (Fennel 1.2.0)
+  - `&into` and `&until` keywords in loops (Fennel 1.2.0)
+  - `match-try` macro (Fennel 1.1.0)
+  - `accumulate` macro (Fennel 0.10.0)
 - More granular highlighting for string escape sequences:
   - `\z` and `\x..` are supported by Lua>=5.2 or LuaJIT, highlighted as error otherwise.
   - `\u{..}` is supported by Lua>=5.3, highlighted as error otherwise.
-- Support `tail!` and `assert-repl` macros (Fennel 1.4.0)
-- Support `case`, `case-try`, and `faccumulate` macros (Fennel 1.3.0)
-- Support `fcollect` macro (Fennel 1.2.0)
-- Support `&into` and `&until` keywords in loops (Fennel 1.2.0).
-- Support `match-try` macro (Fennel 1.1.0).
-- Support `accumulate` macro (Fennel 0.10.0).
 
 ### Fixed
 
-- Support missing `?.`, `comment?`, and `get-scope`
-- Remove highlight for `global` since it has been deprecated (Fennel 1.1.0)
+- Support missing `?.`, `comment?`, and `get-scope`.
+- Remove highlight for deprecated special forms / operators:
+  - `global` (Fennel 1.1.0)
+  - `doc` (Fennel 1.0.0; replaced with `,doc`)
+  - `pick-args` (Fennel 0.10.0)
+  - `require-macros` (Fennel 0.4.0)
 - `&` in identifier is now highlighted as error (Fennel 1.0.0).
-- Remove highlight for `doc` since it has been replaced with `,doc` (Fennel 1.0.0)
-- Remove highlight for `pick-args` since it has been deprecated (Fennel 0.10.0)
-- Remove highlight for `require-macros` since it has been deprecated (Fennel 0.4.0)
 
 ## [0.2][v0.2] (2021-06-20)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
   - `\u{..}` is supported by Lua>=5.3, highlighted as error otherwise.
 - Support `accumulate` macro.
 
+### Fixed
+
+- Remove highlight for `pick-args` since it has been deprecated (Fennel 0.10.0)
+
 ## [0.2][v0.2] (2021-06-20)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - `&` in identifier is now highlighted as error (Fennel 1.0.0).
 - Remove highlight for `doc` since it has been replaced with `,doc` (Fennel 1.0.0)
 - Remove highlight for `pick-args` since it has been deprecated (Fennel 0.10.0)
+- Remove highlight for `require-macros` since it has been deprecated (Fennel 0.4.0)
 
 ## [0.2][v0.2] (2021-06-20)
 

--- a/syntax/fennel.vim
+++ b/syntax/fennel.vim
@@ -46,12 +46,12 @@ syn keyword fennelConstant nil
 " Identifier, symbol, and keyword {{{2
 "
 " <identifier> -> <initial> <subsequent> *
-" where <initial> -> [^#:0-9[:space:]\n"'(),;@\[\]\\`{}~]
-"       <subsequent> ->   [^[:space:]\n"'(),;@\[\]\\`{}~]
-syn match fennelIdentifier /[^#:0-9[:space:]\n"'(),;@\[\]\\`{}~][^[:space:]\n"'(),;@\[\]\\`{}~]*/
+" where <initial> -> [^#&:0-9[:space:]\n"'(),;@\[\]\\`{}~]
+"       <subsequent> ->   [^&[:space:]\n"'(),;@\[\]\\`{}~]
+syn match fennelIdentifier /[^#&:0-9[:space:]\n"'(),;@\[\]\\`{}~][^&[:space:]\n"'(),;@\[\]\\`{}~]*/
 syn match fennelLuaTableItemAccessor /\./ contained containedin=fennelIdentifier
 syn match fennelLuaMethodCall /:/ contained containedin=fennelIdentifier
-syn match fennelSymbol /[^#:0-9[:space:]\n"'(),;@\[\]\\`{}~][^[:space:]\n"'(),;@\[\]\\`{}~]*/ contained
+syn match fennelSymbol /[^#&:0-9[:space:]\n"'(),;@\[\]\\`{}~][^&[:space:]\n"'(),;@\[\]\\`{}~]*/ contained
 " <keyword> -> : <subsequent> +
 " Keyword such as ::: is accepted by Fennel! 
 syn match fennelKeyword /:[^[:space:]\n"'(),;@\[\]\\`{}~]\+/
@@ -151,7 +151,7 @@ syn cluster fennelExpressions contains=fennelSpecialForm,fennelAuxSyntax,fennelL
 " Special forms {{{2
 syn match fennelSpecialForm /\%^\@<!#\ze[^[:space:]\n);@\]\\}~]/
 syn keyword fennelSpecialForm % * + - -> ->> -?> -?>> . .. / // : < <= = > >= ^
-syn keyword fennelSpecialForm and comment do doc doto each eval-compiler fn for global hashfn if
+syn keyword fennelSpecialForm and comment do doto each eval-compiler fn for global hashfn if
 syn keyword fennelSpecialForm include lambda length let local lua macro macros match not not= or
 syn keyword fennelSpecialForm partial quote require-macros set set-forcibly! tset values var when
 syn keyword fennelSpecialForm while ~= λ

--- a/syntax/fennel.vim
+++ b/syntax/fennel.vim
@@ -169,11 +169,14 @@ syn keyword fennelSpecialForm collect icollect
 syn keyword fennelSpecialForm accumulate
 " 1.1.0
 syn keyword fennelSpecialForm match-try
+" 1.2.0
+syn keyword fennelSpecialForm fcollect
 
 " Auxiliary syntaxes {{{2
 syn match fennelAuxSyntax /\$\([1-9]\|\.\.\.\)\?/
 syn keyword fennelAuxSyntax ... _ &
 syn keyword fennelAuxSyntax &as
+syn keyword fennelAuxSyntax &into &until
 " Pattern prefix `?foo` or guard syntax `(matched ? (pred matched)` used in `match` 
 syn match fennelAuxSyntax /\<?\ze\([^[:space:]\n"'(),;@\[\]\\`{}~]\|\>\)/ contained containedin=fennelIdentifier
 " Special suffix for gensym in macro

--- a/syntax/fennel.vim
+++ b/syntax/fennel.vim
@@ -158,13 +158,15 @@ syn keyword fennelSpecialForm while ~= λ
 " Compiler environment
 " TODO: Would be better to highlight these items only inside compiler environment
 syn keyword fennelSpecialForm list sym list? sym? table? sequence? gensym varg? multi-sym? view assert-compile
-syn keyword fennelSpecialForm in-scope? macroexpand
+syn keyword fennelSpecialForm in-scope? macroexpand comment? get-scope
 " 0.4.0
 syn keyword fennelSpecialForm import-macros rshift lshift bor band bnot and bxor pick-values
 " 0.4.2
 syn keyword fennelSpecialForm with-open
 " 0.8.0
 syn keyword fennelSpecialForm collect icollect
+" 0.9.0
+syn keyword fennelSpecialForm ?.
 " 0.10.0
 syn keyword fennelSpecialForm accumulate
 " 1.1.0

--- a/syntax/fennel.vim
+++ b/syntax/fennel.vim
@@ -171,6 +171,8 @@ syn keyword fennelSpecialForm accumulate
 syn keyword fennelSpecialForm match-try
 " 1.2.0
 syn keyword fennelSpecialForm fcollect
+" 1.3.0
+syn keyword fennelSpecialForm case case-try faccumulate
 
 " Auxiliary syntaxes {{{2
 syn match fennelAuxSyntax /\$\([1-9]\|\.\.\.\)\?/

--- a/syntax/fennel.vim
+++ b/syntax/fennel.vim
@@ -160,7 +160,7 @@ syn keyword fennelSpecialForm while ~= λ
 syn keyword fennelSpecialForm list sym list? sym? table? sequence? gensym varg? multi-sym? view assert-compile
 syn keyword fennelSpecialForm in-scope? macroexpand
 " 0.4.0
-syn keyword fennelSpecialForm import-macros rshift lshift bor band bnot and bxor pick-values pick-args
+syn keyword fennelSpecialForm import-macros rshift lshift bor band bnot and bxor pick-values
 " 0.4.2
 syn keyword fennelSpecialForm with-open
 " 0.8.0

--- a/syntax/fennel.vim
+++ b/syntax/fennel.vim
@@ -151,7 +151,7 @@ syn cluster fennelExpressions contains=fennelSpecialForm,fennelAuxSyntax,fennelL
 " Special forms {{{2
 syn match fennelSpecialForm /\%^\@<!#\ze[^[:space:]\n);@\]\\}~]/
 syn keyword fennelSpecialForm % * + - -> ->> -?> -?>> . .. / // : < <= = > >= ^
-syn keyword fennelSpecialForm and comment do doto each eval-compiler fn for global hashfn if
+syn keyword fennelSpecialForm and comment do doto each eval-compiler fn for hashfn if
 syn keyword fennelSpecialForm include lambda length let local lua macro macros match not not= or
 syn keyword fennelSpecialForm partial quote require-macros set set-forcibly! tset values var when
 syn keyword fennelSpecialForm while ~= λ
@@ -165,8 +165,10 @@ syn keyword fennelSpecialForm import-macros rshift lshift bor band bnot and bxor
 syn keyword fennelSpecialForm with-open
 " 0.8.0
 syn keyword fennelSpecialForm collect icollect
-" 0.9.3 / ???
+" 0.10.0
 syn keyword fennelSpecialForm accumulate
+" 1.1.0
+syn keyword fennelSpecialForm match-try
 
 " Auxiliary syntaxes {{{2
 syn match fennelAuxSyntax /\$\([1-9]\|\.\.\.\)\?/

--- a/syntax/fennel.vim
+++ b/syntax/fennel.vim
@@ -173,6 +173,8 @@ syn keyword fennelSpecialForm match-try
 syn keyword fennelSpecialForm fcollect
 " 1.3.0
 syn keyword fennelSpecialForm case case-try faccumulate
+" 1.4.0
+syn keyword fennelSpecialForm tail! assert-repl
 
 " Auxiliary syntaxes {{{2
 syn match fennelAuxSyntax /\$\([1-9]\|\.\.\.\)\?/

--- a/syntax/fennel.vim
+++ b/syntax/fennel.vim
@@ -153,7 +153,7 @@ syn match fennelSpecialForm /\%^\@<!#\ze[^[:space:]\n);@\]\\}~]/
 syn keyword fennelSpecialForm % * + - -> ->> -?> -?>> . .. / // : < <= = > >= ^
 syn keyword fennelSpecialForm and comment do doto each eval-compiler fn for hashfn if
 syn keyword fennelSpecialForm include lambda length let local lua macro macros match not not= or
-syn keyword fennelSpecialForm partial quote require-macros set set-forcibly! tset values var when
+syn keyword fennelSpecialForm partial quote set set-forcibly! tset values var when
 syn keyword fennelSpecialForm while ~= λ
 " Compiler environment
 " TODO: Would be better to highlight these items only inside compiler environment


### PR DESCRIPTION
Close #3
Close #31

- Now supports Fennel 1.4.0.
- Other issues (add/remove some keywords) are also fixed.